### PR TITLE
Add Java assertions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,4 +59,5 @@ shadowJar {
 
 run{
     standardInput = System.in
+    enableAssertions = true
 }

--- a/src/main/java/arguments/Argument.java
+++ b/src/main/java/arguments/Argument.java
@@ -34,6 +34,7 @@ public abstract class Argument<T> {
      */
     public T getParameter() throws DukeException {
         validate();
+        assert value != null;
         return value;
     }
 

--- a/src/main/java/arguments/CompulsoryArgument.java
+++ b/src/main/java/arguments/CompulsoryArgument.java
@@ -7,13 +7,17 @@ import input.Input;
  * Class to represent a compulsory argument which must be provided (can be empty string)
  * @param <T> Type of the argument
  */
-public class CompulsoryArgument<T> extends Argument<T> {
+public abstract class CompulsoryArgument<T> extends Argument<T> {
     private String missingMessage;
     protected CompulsoryArgument(Input input, String argumentName, String missingMessage) {
         super(input, argumentName);
         this.missingMessage = missingMessage;
     }
 
+    /**
+     * Validates that the argument was specified
+     * @throws DukeException if argument was not specified
+     */
     @Override
     public void validate() throws DukeException {
         if (super.value != null) {

--- a/src/main/java/arguments/StringArgument.java
+++ b/src/main/java/arguments/StringArgument.java
@@ -41,5 +41,7 @@ public class StringArgument extends Argument<String> {
         } catch (EmptyArgumentException e) {
             throw new DukeException(e.getMessage());
         }
+
+        assert super.value != null;
     }
 }

--- a/src/main/java/arguments/TaskIdArgument.java
+++ b/src/main/java/arguments/TaskIdArgument.java
@@ -27,5 +27,7 @@ public class TaskIdArgument extends Argument<Integer> {
         } catch (DukeException ex) {
             throw new DukeException("This command needs a task number e.g 1");
         }
+
+        assert super.value != null;
     }
 }

--- a/src/main/java/input/Input.java
+++ b/src/main/java/input/Input.java
@@ -92,6 +92,8 @@ public class Input {
             String strippedArg = currentArg.substring(currentArg.lastIndexOf(ARG_START) + ARG_START.length());
             parameters.put(strippedArg, String.join(DELIMITER, currentBuffer));
         }
+
+        assert !commandName.trim().equals("");
     }
 
     /**

--- a/src/main/java/task/TaskDeserializer.java
+++ b/src/main/java/task/TaskDeserializer.java
@@ -25,6 +25,7 @@ public class TaskDeserializer {
             LocalDateTime by = LocalDateTime.parse(taskObj.getString("by"), Deadline.DATE_FORMATTER);
             return new Deadline(description, by, isDone);
         default:
+            assert false; // assert that default case is never reached
             return null;
         }
     }


### PR DESCRIPTION
Codebase did not use Java assertions before.

Java assertions are commonly used to document important assumptions that hold at important points in the code.

Let's add assertions to important points in the code.